### PR TITLE
Avoid loading the McM's module from a folder in AFS

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,1 @@
+pdmv-http-client @ git+https://github.com/cms-PdmV/mcm_scripts.git

--- a/python/update.py
+++ b/python/update.py
@@ -194,6 +194,12 @@ for year in range(now.year - 2, now.year + 1):
     all_timestamps[f'{year}_monthly'] = get_year_timestamps(year)
 
 print('Timestamp keys: %s' % (', '.join(list(all_timestamps.keys()))))
+
+# Create an output folder to store JSON files
+output_folder = Path().cwd() / Path("output")
+output_folder.mkdir(mode=0o700, exist_ok=True)
+print("Folder to store results: ", output_folder)
+
 for timestamp_name, timestamps in all_timestamps.items():
     # Split all campaigns into nice equal timestamps
     changes = {}
@@ -225,7 +231,7 @@ for timestamp_name, timestamps in all_timestamps.items():
 
     # print(json.dumps(changes, indent=4))
     if len(changes) > 0:
-        f = open(f'{timestamp_name}.json', 'w')
-        json.dump(changes, f)
+        with open(file=output_folder / Path(f"{timestamp_name}.json"), mode="w") as f:
+            json.dump(changes, f)
     else:
         print('No results?')


### PR DESCRIPTION
Related to: [#23](https://github.com/cms-PdmV/mcm_scripts/issues/23)

1. Install this module from its source code using `pip`.

- This update avoids changing the script's code to remove the overwriting section to McM's objects for using it to send requests to pMp. This kind of behavior is widely spread in different scripts and attempting to update it will only create confusion to maintain this in the future. Just leave it as it is.

2. Store output in a dedicated folder

- Instead of storing all the output JSON files directly into the web server's static folder, store them separately at `"$(pwd)/output"`. This removes the dependency of running the update workflow directly on the web server folder and enables the execution of this step in an isolated environment. Update workflow details: [#15](https://gitlab.cern.ch/pdmv/infrastructure-management/-/merge_requests/15)
